### PR TITLE
fixed compiler version error

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -42,6 +42,11 @@ module.exports = {
         currency: 'USD',
         gasPrice: 2
       }
-    }
+    },
+    compilers: {
+      solc: {
+        version: "^0.4.25"
+      }
+    },
   }
 };


### PR DESCRIPTION
> Error parsing /opensea-creatures/contracts/Creature.sol: ParsedContract.sol:3:1: ParserError: Source file requires different compiler version (current compiler is 0.5.2+commit.1df8f40c.Emscripten.clang - note that nightly builds are considered to be strictly less than the released version
> import "./TradeableERC721Token.sol";
> ^----^
> Compilation failed. See above.
> Truffle v5.0.0-beta.2 (core: 5.0.0-beta.2)
> Solidity v0.5.0 (solc-js)
> Node v11.6.0

Fix:

Specyfing solc version:

```
module.exports = {
  ...
  compilers: {
    solc: {
      version: "^0.4.25"
    }
  }
};
```