### PR TITLE
change NFT_CONTRACT_ADDRESS to FACTORY_CONTRACT_ADDRESS

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ After deploying to the Rinkeby network, there will be a contract on Rinkeby that
 
 ```
 export OWNER_ADDRESS="<my_address>"
-export NFT_CONTRACT_ADDRESS="<deployed_contract_address>"
+export FACTORY_CONTRACT_ADDRESS="<deployed_factory_address>"
 export NETWORK="rinkeby"
 node scripts/mint.js
 ```


### PR DESCRIPTION
I went through the default setup and was getting EVM errors when minting. Turns out the default setup creates a factory contract address. exporting FACTORY_CONTRACT_ADDRESS instead of NFT_CONTRACT_ADDRESS solved the problem.