### PR TITLE
yarn truffle deploy on new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ sudo npm explore npm -g -- npm install node-gyp@latest # Update node-gyp
 ```
 export ALCHEMY_KEY="<your_alchemy_project_id>"
 export MNEMONIC="<metmask_mnemonic>"
-DEPLOY_CREATURES_SALE=1 yarn truffle deploy --network rinkeby
+export DEPLOY_CREATURES_SALE=0 
+yarn truffle deploy --network rinkeby
 ```
 
 ### Minting tokens.


### PR DESCRIPTION
`yarn truffle deploy --network rinkeby` is on a new line for readability

`export DEPLOY_CREATURES_SALE=0` is set to 0 so there's no factory contract. Works with `NFT_CONTRACT_ADDRESS`