### PR TITLE
Proposal: use ^ and ~ for `engines` semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "web3": "^1.0.0-beta.34"
   },
   "engines": {
-    "node": "12.18.x",
-    "yarn": "1.22.4"
+    "node": "^12.18.x",
+    "yarn": "~1.22.4"
   },
   "devDependencies": {
     "eslint": "^6.8.0"


### PR DESCRIPTION
This PR:
- Adds `^` to package.json `engines.node` to match any node.js version 12.x
- Adds `~` to package.json `engines.yarn` to match any yarn version `1.22.x`