### PR TITLE
Max/2021/03/factory mint fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ DEPLOY_CREATURES_SALE=1 yarn truffle deploy --network rinkeby
 
 ### Minting tokens.
 
-After deploying to the Rinkeby network, there will be a contract on Rinkeby that will be viewable on [Rinkeby Etherscan](https://rinkeby.etherscan.io). For example, here is a [recently deployed contract](https://rinkeby.etherscan.io/address/0xeba05c5521a3b81e23d15ae9b2d07524bc453561). You should set this contract address and the address of your Metamask account as environment variables when running the minting script:
+After deploying to the Rinkeby network, there will be a contract on Rinkeby that will be viewable on [Rinkeby Etherscan](https://rinkeby.etherscan.io). For example, here is a [recently deployed contract](https://rinkeby.etherscan.io/address/0xeba05c5521a3b81e23d15ae9b2d07524bc453561). You should set this contract address and the address of your Metamask account as environment variables when running the minting script. If a [CreatureFactory was deployed](https://github.com/ProjectOpenSea/opensea-creatures/blob/master/migrations/2_deploy_contracts.js#L38), which the sample deploy steps above do, you'll also need to specify its address below as it will be the owner on the NFT contract, and only it will have mint permissions.
 
 ```
 export OWNER_ADDRESS="<my_address>"
 export NFT_CONTRACT_ADDRESS="<deployed_contract_address>"
+export FACTORY_CONTRACT_ADDRESS="<deployed_factory_contract_address>"
 export NETWORK="rinkeby"
 node scripts/mint.js
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ DEPLOY_CREATURES_SALE=1 yarn truffle deploy --network rinkeby
 
 ### Minting tokens.
 
-After deploying to the Rinkeby network, there will be a contract on Rinkeby that will be viewable on [Rinkeby Etherscan](https://rinkeby.etherscan.io). For example, here is a [recently deployed contract](https://rinkeby.etherscan.io/address/0xeba05c5521a3b81e23d15ae9b2d07524bc453561). You should set this contract address and the address of your Metamask account as environment variables when running the minting script. If a [CreatureFactory was deployed](https://github.com/ProjectOpenSea/opensea-creatures/blob/master/migrations/2_deploy_contracts.js#L38), which the sample deploy steps above do, you'll also need to specify its address below as it will be the owner on the NFT contract, and only it will have mint permissions.
+After deploying to the Rinkeby network, there will be a contract on Rinkeby that will be viewable on [Rinkeby Etherscan](https://rinkeby.etherscan.io). For example, here is a [recently deployed contract](https://rinkeby.etherscan.io/address/0xeba05c5521a3b81e23d15ae9b2d07524bc453561). You should set this contract address and the address of your Metamask account as environment variables when running the minting script. If a [CreatureFactory was deployed](https://github.com/ProjectOpenSea/opensea-creatures/blob/master/migrations/2_deploy_contracts.js#L38), which the sample deploy steps above do, you'll need to specify its address below as it will be the owner on the NFT contract, and only it will have mint permissions. In that case, you won't need NFT_CONTRACT_ADDRESS, as all we need is the contract with mint permissions here.
 
 ```
 export OWNER_ADDRESS="<my_address>"

--- a/scripts/mint.js
+++ b/scripts/mint.js
@@ -68,21 +68,7 @@ async function main() {
   );
   const web3Instance = new web3(provider);
 
-  if (NFT_CONTRACT_ADDRESS) {
-    const nftContract = new web3Instance.eth.Contract(
-      NFT_ABI,
-      NFT_CONTRACT_ADDRESS,
-      { gasLimit: "1000000" }
-    );
-
-    // Creatures issued directly to the owner.
-    for (var i = 0; i < NUM_CREATURES; i++) {
-      const result = await nftContract.methods
-        .mintTo(OWNER_ADDRESS)
-        .send({ from: OWNER_ADDRESS });
-      console.log("Minted creature. Transaction: " + result.transactionHash);
-    }
-  } else if (FACTORY_CONTRACT_ADDRESS) {
+  if (FACTORY_CONTRACT_ADDRESS) {
     const factoryContract = new web3Instance.eth.Contract(
       FACTORY_ABI,
       FACTORY_CONTRACT_ADDRESS,
@@ -103,6 +89,20 @@ async function main() {
         .mint(LOOTBOX_OPTION_ID, OWNER_ADDRESS)
         .send({ from: OWNER_ADDRESS });
       console.log("Minted lootbox. Transaction: " + result.transactionHash);
+    }
+  } else if (NFT_CONTRACT_ADDRESS) {
+    const nftContract = new web3Instance.eth.Contract(
+      NFT_ABI,
+      NFT_CONTRACT_ADDRESS,
+      { gasLimit: "1000000" }
+    );
+
+    // Creatures issued directly to the owner.
+    for (var i = 0; i < NUM_CREATURES; i++) {
+      const result = await nftContract.methods
+        .mintTo(OWNER_ADDRESS)
+        .send({ from: OWNER_ADDRESS });
+      console.log("Minted creature. Transaction: " + result.transactionHash);
     }
   } else {
     console.error(


### PR DESCRIPTION
In our deploy setup, ownership / minting capabilities are transferred to the factory contract. This causes mint.js to fail with the default README deployment instructions as the contract deployer / creator will not be able to mint with the primary NFT token contract directly anymore.

Added clarifying instructions to specify FACTORY_CONTRACT_ADDRESS in the README if a factory was deployed, and also moved the check for that address first in the mint script as that is the more "exceptional" first case that should have priority in terms of how to mint.