### PR TITLE
Unused parameters removal

### DIFF
--- a/contracts/CreatureAccessoryFactory.sol
+++ b/contracts/CreatureAccessoryFactory.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.0;
 
-import "openzeppelin-solidity/contracts/access/Ownable.sol";
-import "openzeppelin-solidity/contracts/security/ReentrancyGuard.sol";
-import "openzeppelin-solidity/contracts/utils/Strings.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
 import "./IFactoryERC1155.sol";
 import "./ERC1155Tradable.sol";
 

--- a/contracts/CreatureAccessoryLootBox.sol
+++ b/contracts/CreatureAccessoryLootBox.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.0;
 
-import "openzeppelin-solidity/contracts/security/ReentrancyGuard.sol";
-import "openzeppelin-solidity/contracts/utils/math/SafeMath.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "./ERC1155Tradable.sol";
 import "./LootBoxRandomness.sol";
 

--- a/contracts/CreatureFactory.sol
+++ b/contracts/CreatureFactory.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.0;
 
-import "openzeppelin-solidity/contracts/access/Ownable.sol";
-import "openzeppelin-solidity/contracts/utils/Strings.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
 import "./IFactoryERC721.sol";
 import "./Creature.sol";
 import "./CreatureLootBox.sol";

--- a/contracts/CreatureFactory.sol
+++ b/contracts/CreatureFactory.sol
@@ -134,7 +134,7 @@ contract CreatureFactory is FactoryERC721, Ownable {
      * Use transferFrom so the frontend doesn't have to worry about different method names.
      */
     function transferFrom(
-        address _from,
+        address,
         address _to,
         uint256 _tokenId
     ) public {
@@ -169,7 +169,7 @@ contract CreatureFactory is FactoryERC721, Ownable {
      * Hack to get things to work automatically on OpenSea.
      * Use isApprovedForAll so the frontend doesn't have to worry about different method names.
      */
-    function ownerOf(uint256 _tokenId) public view returns (address _owner) {
+    function ownerOf(uint256) public view returns (address _owner) {
         return owner();
     }
 }

--- a/contracts/CreatureLootBox.sol
+++ b/contracts/CreatureLootBox.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.0;
 import "./ERC721Tradable.sol";
 import "./Creature.sol";
 import "./IFactoryERC721.sol";
-import "openzeppelin-solidity/contracts/access/Ownable.sol";
 
 /**
  * @title CreatureLootBox

--- a/contracts/ERC1155Tradable.sol
+++ b/contracts/ERC1155Tradable.sol
@@ -2,10 +2,10 @@
 
 pragma solidity ^0.8.0;
 
-import "openzeppelin-solidity/contracts/access/Ownable.sol";
-import "openzeppelin-solidity/contracts/token/ERC1155/ERC1155.sol";
-import "openzeppelin-solidity/contracts/utils/math/SafeMath.sol";
-import "openzeppelin-solidity/contracts/utils/Strings.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
 
 import "./common/meta-transactions/ContentMixin.sol";
 import "./common/meta-transactions/NativeMetaTransaction.sol";

--- a/contracts/LootBoxRandomness.sol
+++ b/contracts/LootBoxRandomness.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import "openzeppelin-solidity/contracts/utils/math/SafeMath.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 
 /*
   DESIGN NOTES:

--- a/contracts/common/meta-transactions/NativeMetaTransaction.sol
+++ b/contracts/common/meta-transactions/NativeMetaTransaction.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import {SafeMath} from  "openzeppelin-solidity/contracts/utils/math/SafeMath.sol";
+import {SafeMath} from  "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import {EIP712Base} from "./EIP712Base.sol";
 
 contract NativeMetaTransaction is EIP712Base {

--- a/contracts/test/MockProxyRegistry.sol
+++ b/contracts/test/MockProxyRegistry.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 
-import 'openzeppelin-solidity/contracts/access/Ownable.sol';
+import '@openzeppelin/contracts/access/Ownable.sol';
 
 
 /**

--- a/contracts/test/TestForReentrancyAttack.sol
+++ b/contracts/test/TestForReentrancyAttack.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import "openzeppelin-solidity/contracts/token/ERC1155/IERC1155Receiver.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 
 import "../CreatureAccessoryFactory.sol";
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "eth-sig-util": "^3.0.1",
     "ethereum-waffle": "^3.0.0",
     "opensea-js": "^1.1.5",
-    "openzeppelin-solidity": "~4.1.0",
+    "@openzeppelin/contracts": "4.4.0",
     "truffle": "^5.1.30",
     "truffle-assertions": "^0.9.2",
     "truffle-contract-size": "^2.0.1",
@@ -32,7 +32,7 @@
     "web3": "^1.0.0-beta.34"
   },
   "engines": {
-    "node": "^12.18.x",
+    "node": "^14.15.x",
     "yarn": "~1.22.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Current guidance for solidity is to just remove the variable name to get rid of those warnings.

[Source](https://github.com/ethereum/solidity/issues/6098)