### PR TITLE
Remove name from unused variables to get rid of warnings

### DIFF
--- a/contracts/CreatureFactory.sol
+++ b/contracts/CreatureFactory.sol
@@ -134,7 +134,7 @@ contract CreatureFactory is FactoryERC721, Ownable {
      * Use transferFrom so the frontend doesn't have to worry about different method names.
      */
     function transferFrom(
-        address _from,
+        address,
         address _to,
         uint256 _tokenId
     ) public {
@@ -169,7 +169,7 @@ contract CreatureFactory is FactoryERC721, Ownable {
      * Hack to get things to work automatically on OpenSea.
      * Use isApprovedForAll so the frontend doesn't have to worry about different method names.
      */
-    function ownerOf(uint256 _tokenId) public view returns (address _owner) {
+    function ownerOf(uint256) public view returns (address _owner) {
         return owner();
     }
 }


### PR DESCRIPTION
Current guidance for solidity is to just remove the variable name to get rid of those warnings.

[Source](https://github.com/ethereum/solidity/issues/6098)